### PR TITLE
Restore spawnpoint.

### DIFF
--- a/packages/client/public/scenes/terrain.scn
+++ b/packages/client/public/scenes/terrain.scn
@@ -1,6 +1,12 @@
 {
   "objects": [
     {
+      "type": "application/spawnpoint",
+      "content": {
+        "position": [0, 100, 0]
+      }
+    },
+    {
       "type": "application/light",
       "content": {
         "lightType": "ambient",

--- a/packages/compiler/public/type_templates/spawnpoint.js
+++ b/packages/compiler/public/type_templates/spawnpoint.js
@@ -1,11 +1,12 @@
 import * as THREE from 'three';
 import metaversefile from 'metaversefile';
-const {useApp, useLocalPlayer, usePartyManager} = metaversefile;
+const {useApp, useLocalPlayer, usePartyManager, useSpawnManager} = metaversefile;
 
 const localEuler = new THREE.Euler(0, 0, 0, 'YXZ');
 
 export default e => {
   const app = useApp();
+  const spawnManager = useSpawnManager();
   
   const srcUrl = ${this.srcUrl};
   const mode = app.getComponent('mode') ?? 'attached';
@@ -47,18 +48,19 @@ export default e => {
             });
           });
         }
+        spawnManager.setSpawnPoint(position, quaternion);
 
-        // position all party members offset to spawnpoint
-        const diff = new THREE.Vector3();
-        const playerPosition = new THREE.Vector3();
-        const partyManager = usePartyManager();
-        const partyMembers = partyManager.getPartyPlayers();
+        // // position all party members offset to spawnpoint
+        // const diff = new THREE.Vector3();
+        // const playerPosition = new THREE.Vector3();
+        // const partyManager = usePartyManager();
+        // const partyMembers = partyManager.getPartyPlayers();
 
-        diff.subVectors(position, localPlayer.position);
-        for (const player of partyMembers) {
-          playerPosition.addVectors(diff, player.position);
-          player.setSpawnPoint(playerPosition, quaternion);
-        }
+        // diff.subVectors(position, localPlayer.position);
+        // for (const player of partyMembers) {
+        //   playerPosition.addVectors(diff, player.position);
+        //   player.setSpawnPoint(playerPosition, quaternion);
+        // }
       }
     })();
   }


### PR DESCRIPTION
Restore `spawnpoint` feature to prevent spawn below ground in terrain scene.
( I don't think `party` feature is working now, so only set `localPlayer`'s spawnpoint directly )